### PR TITLE
Move the applying of MeterFilters to the MeterRegistryRegistrar

### DIFF
--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/MeterBinderRegistrar.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/MeterBinderRegistrar.java
@@ -47,12 +47,7 @@ public class MeterBinderRegistrar implements InitializingBean, ApplicationContex
             return;
         }
 
-        this.addFilters(meterRegistry);
         this.addBinders(meterRegistry);
-    }
-
-    protected void addFilters(final MeterRegistry registry) {
-        ctx.getBeansOfType(MeterFilter.class).values().forEach(registry.config()::meterFilter);
     }
 
     private void addBinders(final MeterRegistry registry) {

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/care4alf/Care4AlfMeterBinderRegistrar.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/care4alf/Care4AlfMeterBinderRegistrar.java
@@ -2,6 +2,7 @@ package eu.xenit.alfred.telemetry.binder.care4alf;
 
 import eu.xenit.alfred.telemetry.binder.MeterBinderRegistrar;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import org.slf4j.Logger;
@@ -12,16 +13,18 @@ public class Care4AlfMeterBinderRegistrar extends MeterBinderRegistrar {
     private static final Logger LOGGER = LoggerFactory.getLogger(Care4AlfMeterBinderRegistrar.class);
 
     public Care4AlfMeterBinderRegistrar(MeterRegistry meterRegistry) {
-        super(new CompositeMeterRegistry().add(meterRegistry));
+        super(wrapRegistry(meterRegistry));
         this.filtersEnabledByDefault = false;
     }
 
-    @Override
-    protected void addFilters(MeterRegistry registry) {
-        super.addFilters(registry);
-        registry.config()
-                .meterFilter(MeterFilter.replaceTagValues("application", s -> "c4a"))
+    private static MeterRegistry wrapRegistry(final MeterRegistry originalRegistry) {
+        final MeterRegistry wrapped = new CompositeMeterRegistry().add(originalRegistry);
+
+        wrapped.config()
+                .meterFilter(MeterFilter.commonTags(Tags.of("application", "c4a")))
                 .meterFilter(new TicketMetricsMeterFilter());
+
+        return wrapped;
     }
 
     @Override

--- a/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/context/registry-context.xml
+++ b/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/context/registry-context.xml
@@ -12,14 +12,6 @@
     <bean id="alfred-telemetry.RegistryRegistrar"
             class="eu.xenit.alfred.telemetry.registry.RegistryRegistrar">
         <constructor-arg ref="meterRegistry"/>
-        <constructor-arg>
-            <list>
-                <ref bean="alfred-telemetry.SimpleRegistryFactoryWrapper"/>
-                <ref bean="alfred-telemetry.JmxRegistryFactoryWrapper"/>
-                <ref bean="alfred-telemetry.GraphiteRegistryFactoryWrapper"/>
-                <ref bean="alfred-telemetry.PrometheusRegistryFactoryWrapper"/>
-            </list>
-        </constructor-arg>
     </bean>
 
     <!-- Simple Meter registry -->

--- a/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/binder/MeterBinderRegistrarTest.java
+++ b/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/binder/MeterBinderRegistrarTest.java
@@ -109,19 +109,6 @@ class MeterBinderRegistrarTest {
                     is(1));
         }
 
-        @Test
-        void addMeterFilters() {
-            MeterFilter mockedFilter = MeterFilter.commonTags(Tags.of("stop", "hammertime"));
-            when(applicationContext.getBeansOfType(MeterFilter.class))
-                    .thenReturn(Collections.singletonMap("filter", mockedFilter));
-
-            registrar.afterPropertiesSet();
-
-            Counter testCounter = registrar.getMeterRegistry().find(BasicTestMetrics.COUNTER_NAME).counter();
-            assertThat(testCounter, is(not(nullValue())));
-            assertThat(testCounter.getId().getTag("stop"), is("hammertime"));
-        }
-
     }
 
     @Nested


### PR DESCRIPTION
The problem was that the applying of the `MeterFilter`s was associated with the registering of the `MeterBinder`s. This should be done on the `MeterRegistry` level, before registering the  `MeterRegistry` in the global `CompositeMeterRegistry`