### PR TITLE
Include Grafana DB dashboard, small changes to improve test setup

### DIFF
--- a/integration-tests/src/test/resources/compose/docker-compose-graphite.yml
+++ b/integration-tests/src/test/resources/compose/docker-compose-graphite.yml
@@ -8,9 +8,11 @@ services:
     - GLOBAL_metrics.restMetricsReporter.path.enabled=true
 
   carbon:
-    image: hub.xenit.eu/public/carbon:0.0.1-4
+    image: hub.xenit.eu/public/carbon:0.9.16
     volumes:
     - whisperdb:/opt/graphite/storage/whisper
+    environment:
+      - MAX_CREATES_PER_MINUTE=inf
 
   monitor-graphite-api:
     image: hub.xenit.eu/public/graphite-api:0.0.1-10

--- a/integration-tests/src/test/resources/compose/docker-compose.yml
+++ b/integration-tests/src/test/resources/compose/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - GLOBAL_alfred.telemetry.alfresco-integration.enabled=true
       # Enable Care4Alf metrics:
       - GLOBAL_alfred.telemetry.binder.care4alf.enabled=true
+      # Enable Alfresco cache metrics:
+      - GLOBAL_alfred.telemetry.binder.cache.enabled=true
 
   postgresql:
     image: docker.io/xenit/postgres

--- a/integration-tests/src/test/resources/compose/graphite/grafana/dashboards/Database.json
+++ b/integration-tests/src/test/resources/compose/graphite/grafana/dashboards/Database.json
@@ -1,0 +1,211 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 2,
+  "iteration": 1573571270732,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "graphite",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "hide": false,
+          "refCount": 0,
+          "refId": "A",
+          "target": "alias($application.$server.jdbc.connections.count.name.dbcp.status.active, 'Active Connections')"
+        },
+        {
+          "hide": false,
+          "refCount": 0,
+          "refId": "B",
+          "target": "alias($application.$server.jdbc.connections.count.name.dbcp.status.idle, 'Idle Connections')"
+        },
+        {
+          "hide": true,
+          "refCount": 0,
+          "refId": "C",
+          "target": "alias($application.$server.jdbc.connections.max.name.dbcp, 'Max Connections')"
+        },
+        {
+          "hide": true,
+          "refCount": 0,
+          "refId": "D",
+          "target": "alias($application.$server.jdbc.connections.min.name.dbcp, 'Min Connections')"
+        },
+        {
+          "hide": true,
+          "refCount": 0,
+          "refId": "E",
+          "target": "$application.$server.jdbc.connections.usage.name.dbcp"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Panel Title",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "graphite",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Application",
+        "multi": true,
+        "name": "application",
+        "options": [],
+        "query": "*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "graphite",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Server",
+        "multi": true,
+        "name": "server",
+        "options": [],
+        "query": "$application.*",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Database",
+  "uid": "zT5j1bJWz",
+  "version": 1
+}


### PR DESCRIPTION
- Updated to the 'official' Xenit Carbon image: `hub.xenit.eu/public/carbon:0.9.16`
- Included `MAX_CREATES_PER_MINUTE=inf`, because the default of '50' is not really feasible for a test setup. (A lot more metrics are created.)
- Include Grafana Database.json dashboard