### PR TITLE
SOLR-DISABLE-FLOC-ID: Added floc-id-enabled property.

### DIFF
--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/solr/SolrMetricsBeanPostProcessor.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/solr/SolrMetricsBeanPostProcessor.java
@@ -1,5 +1,6 @@
 package eu.xenit.alfred.telemetry.binder.solr;
 
+import eu.xenit.alfred.telemetry.binder.solr.sharding.SolrShardingMetrics;
 import eu.xenit.alfred.telemetry.binder.solr.sharding.SolrShardingMetricsFactory;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Properties;
@@ -24,6 +25,7 @@ public class SolrMetricsBeanPostProcessor implements BeanDefinitionRegistryPostP
     public static final String SOLR_SHARDING_METRICS_CRON_PROPERTY = "alfred.telemetry.binder.solr.sharding.cronexpression";
     public static final String SOLR_SHARDING_METRICS_ENABLED_PROPERTY = "alfred.telemetry.binder.solr.sharding.enabled";
     public static final String QUARTZ_CHECK_CLASS = "org.quartz.ScheduleBuilder";
+    public static final String SOLR_SHARDING_METRICS_FLOC_ID_ENABLED_PROPERTY = "alfred.telemetry.binder.solr.sharding.floc.id.enabled";
     private final Scheduler scheduler;
     private final Properties globalProperties;
 
@@ -66,6 +68,7 @@ public class SolrMetricsBeanPostProcessor implements BeanDefinitionRegistryPostP
         constructorArgumentValues.addGenericArgumentValue(meterRegistry);
         constructorArgumentValues.addGenericArgumentValue(scheduler);
         constructorArgumentValues.addGenericArgumentValue(globalProperties.get(SOLR_SHARDING_METRICS_CRON_PROPERTY));
+        constructorArgumentValues.addGenericArgumentValue(Boolean.parseBoolean(globalProperties.getProperty(SOLR_SHARDING_METRICS_FLOC_ID_ENABLED_PROPERTY)));
         solrShardingMetricsBean.setConstructorArgumentValues(constructorArgumentValues);
         solrShardingMetricsBean.setBeanClass(SolrShardingMetricsFactory.class);
         beanDefinitionRegistry.registerBeanDefinition(SOLR_SHARDING_METRICS_BEAN_ID, solrShardingMetricsBean);

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/solr/sharding/SolrShardingMetrics.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/solr/sharding/SolrShardingMetrics.java
@@ -21,13 +21,15 @@ public class SolrShardingMetrics {
     private static final Logger LOGGER = LoggerFactory.getLogger(SolrShardingMetrics.class);
 
     public static final String SOLR_SHARDING_METRICS_PREFIX = "solr.sharding";
+    private boolean flocIdEnabled;
 
     private SolrShardingMetricsContainer solrShardingMetricsContainer;
     private MeterRegistry registry;
 
-    public SolrShardingMetrics(ShardRegistry shardRegistry, MeterRegistry registry) {
+    public SolrShardingMetrics(ShardRegistry shardRegistry, MeterRegistry registry, boolean flocIdEnabled) {
         this.solrShardingMetricsContainer = new SolrShardingMetricsContainer(shardRegistry);
         this.registry = registry;
+        this.flocIdEnabled = flocIdEnabled;
     }
 
     private Map<String, AtomicLong> metrics = new HashMap<>();
@@ -36,7 +38,8 @@ public class SolrShardingMetrics {
         LOGGER.debug("Updating metrics");
         solrShardingMetricsContainer.refresh();
         solrShardingMetricsContainer.getFlocs().forEach(floc -> {
-            final Tags flocTags = Tags.of("floc", String.valueOf(floc.hashCode()))
+            //Disable floc id if option is disabled so we don't have the problems of having to chose the floc in grafana
+            final Tags flocTags = Tags.of("floc", String.valueOf(flocIdEnabled ? floc.hashCode() : 1))
                     .and(floc.getStoreRefs().stream().map(storeRef -> Tag
                             .of("storeRef", String.format("%s_%s", storeRef.getProtocol(), storeRef.getIdentifier())))
                             .collect(Collectors.toSet()));

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/solr/sharding/SolrShardingMetricsFactory.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/solr/sharding/SolrShardingMetricsFactory.java
@@ -14,12 +14,12 @@ import org.quartz.TriggerBuilder;
 public class SolrShardingMetricsFactory {
 
     public SolrShardingMetricsFactory(ShardRegistry shardRegistry, MeterRegistry registry, Scheduler scheduler,
-            String updateCron) throws SchedulerException {
+            String updateCron, Boolean flocIdEnabled) throws SchedulerException {
 
         JobBuilder jobBuilder = JobBuilder.newJob(SolrShardingMetricsScheduledJob.class);
         JobDataMap data = new JobDataMap();
         data.put(SolrShardingMetricsScheduledJob.SOLR_SHARDING_METRICS,
-                new SolrShardingMetrics(shardRegistry, registry));
+                new SolrShardingMetrics(shardRegistry, registry, flocIdEnabled));
         JobDetail jobDetail = jobBuilder.usingJobData(data).withIdentity("SolrShardingMetricsJob").build();
 
         Trigger trigger = TriggerBuilder.newTrigger().withSchedule(CronScheduleBuilder.cronSchedule(updateCron))

--- a/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/alfresco-global.properties
+++ b/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/alfresco-global.properties
@@ -58,4 +58,5 @@ alfred.telemetry.binder.legacy-jdbc.enabled=false
 ## Support for Solr metrics
 alfred.telemetry.binder.solr.sharding.cronexpression=0/10 * * * * ?
 alfred.telemetry.binder.solr.sharding.enabled=true
+alfred.telemetry.binder.solr.sharding.floc.id.enabled=true
 alfred.telemetry.binder.solr.tracking.enabled=true

--- a/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/binder/solr/sharding/SolrShardingMetricsTest.java
+++ b/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/binder/solr/sharding/SolrShardingMetricsTest.java
@@ -44,7 +44,7 @@ class SolrShardingMetricsTest {
 
         ShardRegistry shardRegistry = Mockito.mock(ShardRegistry.class);
         MeterRegistry meterRegistry = new SimpleMeterRegistry();
-        SolrShardingMetrics solrShardingMetrics = new SolrShardingMetrics(shardRegistry, meterRegistry);
+        SolrShardingMetrics solrShardingMetrics = new SolrShardingMetrics(shardRegistry, meterRegistry, true);
 
         when(shardRegistry.getFlocs()).thenReturn(metricsInformation);
         solrShardingMetrics.updateMetrics();

--- a/docs/README.md
+++ b/docs/README.md
@@ -93,7 +93,7 @@ alfred.telemetry.export.graphite.tags-as-prefix=application,host
 If you want Graphite support in your Alfresco docker image, you'll also need to add the following
 in your build.gradle:
 ```groovy
-alfrescoSM "io.micrometer:micrometer-registry-graphite:${last-version}"
+alfrescoSM "io.micrometer:micrometer-registry-graphite:${version}"
 ```
 ## JMX
 
@@ -244,6 +244,7 @@ Metrics provided
 
 ## Solr metrics
 
+
 ### Solr tracking metrics
 **Control Property**: `alfred.telemetry.binder.solr.tracking.enabled`
 
@@ -259,10 +260,14 @@ Metrics provided
 ### Solr sharding metrics
 Solr sharding metrics are only available on Alfresco enterprise versions greater than 6.0.
 
-**Control Property**: `alfred.telemetry.binder.solr.sharding.enabled`
+**Control Property**: 
+
+`alfred.telemetry.binder.solr.sharding.enabled` :Enable solr sharding metrics
+
+`alfred.telemetry.binder.solr.sharding.floc.id.enabled`: This option is enabled by default. If this option is disabled, then it will always use a floc id of 1 for the output metrics folder. On a restart, alfresco always generates a new floc id which can be annoying (for example in Grafana)
 
 | Name                                         | Available tags                                                                              | Values                       |
-|--:-------------------------------------------|--:------------------------------------------------------------------------------------------|--:---------------------------|
+|:-------------------------------------------|:------------------------------------------------------------------------------------------|:---------------------------|
 | solr.sharding.shards                         | floc:[*], storeRef:[workspace_SpacesStore, archive_SpacesStore]                             |                              |
 | solr.sharding.shardInstances                 | floc:[*], storeRef:[workspace_SpacesStore, archive_SpacesStore], shard:[*], instanceHost[*] |                              |
 | solr.sharding.lastIndexedChangeSetId         | floc:[*], storeRef:[workspace_SpacesStore, archive_SpacesStore], shard:[*], instanceHost[*] |                              |


### PR DESCRIPTION
I used a static variable since it isn't easy to obtain the globalProperties. I'm new to Spring and figuring that out would take a while.
This feature will also be removed in the future anyway.

If you believe this is terrible code, please point me in the right direction on how I could get access to globalProperties in SolrShardingMetrics.