### PR TITLE
Renamed NodeMetrics to AlfrescoNodeMeterBinder

### DIFF
--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/AlfrescoNodeMeterBinder.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/AlfrescoNodeMeterBinder.java
@@ -14,9 +14,9 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.ToDoubleFunction;
 
-public class NodeMetrics implements MeterBinder {
+public class AlfrescoNodeMeterBinder implements MeterBinder {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NodeMetrics.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AlfrescoNodeMeterBinder.class);
 
     public static final String ACL_PREFIX = "alfresco.acl";
     public static final String DAO_PREFIX = "alfresco.node";
@@ -26,7 +26,7 @@ public class NodeMetrics implements MeterBinder {
     private NodeDAO nodeDAO;
     private AclDAO aclDAO;
 
-    public NodeMetrics(NodeDAO nodeDAOComponent, AclDAO aclDAOComponent, TransactionService transactionService) {
+    public AlfrescoNodeMeterBinder(NodeDAO nodeDAOComponent, AclDAO aclDAOComponent, TransactionService transactionService) {
         this.nodeDAO = nodeDAOComponent;
         this.aclDAO = aclDAOComponent;
         this.transactionService = transactionService;

--- a/alfred-telemetry-platform/src/main/resources/alfresco/subsystems/Search/solr-sharding-metrics-context.xml
+++ b/alfred-telemetry-platform/src/main/resources/alfresco/subsystems/Search/solr-sharding-metrics-context.xml
@@ -16,7 +16,7 @@
         <constructor-arg value="${alfred.telemetry.binder.solr.tracking.enabled}"/>
     </bean>
 
-    <bean id="alfred-telemetry.NodeMetrics" class="eu.xenit.alfred.telemetry.binder.NodeMetrics">
+    <bean id="alfred-telemetry.NodeMetrics" class="eu.xenit.alfred.telemetry.binder.AlfrescoNodeMeterBinder">
         <constructor-arg ref="nodeDAO"/>
         <constructor-arg ref="aclDAO" />
         <constructor-arg ref="transactionService"/>

--- a/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/binder/NodeMetricsTest.java
+++ b/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/binder/NodeMetricsTest.java
@@ -24,7 +24,7 @@ public class NodeMetricsTest {
         NodeDAO nodeDAO = Mockito.mock(NodeDAO.class);
         AclDAO aclDAO = Mockito.mock(AclDAO.class);
         TransactionService transactionService = createTransactionService();
-        NodeMetrics nodeMetrics = new NodeMetrics(nodeDAO, aclDAO, transactionService);
+        AlfrescoNodeMeterBinder nodeMetrics = new AlfrescoNodeMeterBinder(nodeDAO, aclDAO, transactionService);
         nodeMetrics.bindTo(meterRegistry);
         when(nodeDAO.getMaxNodeId()).thenReturn(1L);
         assertThat(


### PR DESCRIPTION
Renamed NodeMetrics to AlfrescoNodeMeterBinder. This needs to be renamed because MeterBinderRegistar automatically checks for the property based on the classname. Right now the property: `alfred.telemetry.binder.alfresco-node.enabled=true` does not work. With this fix, it will work.