### PR TITLE
Moved AlfrescoNodeMeterBinder bean defintion to correct file

### DIFF
--- a/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/context/binder-context.xml
+++ b/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/context/binder-context.xml
@@ -23,6 +23,11 @@
     <bean class="eu.xenit.alfred.telemetry.binder.JvmMetrics"/>
     <bean class="eu.xenit.alfred.telemetry.binder.FilesMetrics"/>
     <bean class="eu.xenit.alfred.telemetry.binder.ProcessMetrics"/>
+    <bean class="eu.xenit.alfred.telemetry.binder.AlfrescoNodeMeterBinder">
+        <constructor-arg ref="nodeDAO"/>
+        <constructor-arg ref="aclDAO" />
+        <constructor-arg ref="transactionService"/>
+    </bean>
     <bean class="io.micrometer.core.instrument.binder.system.ProcessorMetrics"/>
     <bean class="io.micrometer.core.instrument.binder.system.UptimeMetrics"/>
 

--- a/alfred-telemetry-platform/src/main/resources/alfresco/subsystems/Search/solr-sharding-metrics-context.xml
+++ b/alfred-telemetry-platform/src/main/resources/alfresco/subsystems/Search/solr-sharding-metrics-context.xml
@@ -16,10 +16,4 @@
         <constructor-arg value="${alfred.telemetry.binder.solr.tracking.enabled}"/>
     </bean>
 
-    <bean id="alfred-telemetry.NodeMetrics" class="eu.xenit.alfred.telemetry.binder.AlfrescoNodeMeterBinder">
-        <constructor-arg ref="nodeDAO"/>
-        <constructor-arg ref="aclDAO" />
-        <constructor-arg ref="transactionService"/>
-    </bean>
-
 </beans>


### PR DESCRIPTION
AlfrescoNode metrics did not load. The cause of this is because the bean defintion was in the wrong file. I moved it to the correct file.