### PR TITLE
Configure nexus publishing plugin to handle publishing to sonatype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,20 @@ Version template:
 
 ## [0.4.0] - UNRELEASED
 
+## [0.3.1] - 2020-12-11
+
+### Fixed
+
+* Rename solr projects and embed its dependencies [[#54]]
+* Fix publication to maven central [[#55]]
+
+[#54]: https://github.com/xenit-eu/alfred-telemetry/pull/54
+[#55]: https://github.com/xenit-eu/alfred-telemetry/pull/55
+
+
 ## [0.3.0] - 2020-12-10
+
+*This release was not published due to errors during the publication process*
 
 ### Added
 

--- a/alfred-telemetry-solr/alfred-telemetry-solr-common/build.gradle
+++ b/alfred-telemetry-solr/alfred-telemetry-solr-common/build.gradle
@@ -3,8 +3,11 @@ plugins {
     id 'eu.xenit.alfresco'
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    withJavadocJar()
+    withSourcesJar()
+}
 
 apply from: '../jcenter.gradle'
 

--- a/alfred-telemetry-solr/alfred-telemetry-solr4/build.gradle
+++ b/alfred-telemetry-solr/alfred-telemetry-solr4/build.gradle
@@ -5,7 +5,9 @@ plugins {
     id 'eu.xenit.alfresco'
 }
 
-sourceCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+}
 
 apply from: './overload.gradle'
 apply from: '../jcenter.gradle'

--- a/alfred-telemetry-solr/alfred-telemetry-solr6/build.gradle
+++ b/alfred-telemetry-solr/alfred-telemetry-solr6/build.gradle
@@ -4,7 +4,10 @@ plugins {
     id 'com.github.johnrengelman.shadow'
     id 'eu.xenit.alfresco'
 }
-sourceCompatibility = 11
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+}
 
 apply from: './overload.gradle'
 apply from: '../jcenter.gradle'

--- a/alfred-telemetry-solr/build.gradle
+++ b/alfred-telemetry-solr/build.gradle
@@ -13,9 +13,42 @@ subprojects {
 
     apply from: "${project.projectDir}/overload.gradle"
 
+    description = "Alfred Telemetry Solr extension for ${solrFlavor} which enables exposure of Metrics using Micrometer"
+
     plugins.withId('java') {
+        configurations {
+            implementationSources {
+                canBeResolved = true
+                canBeConsumed = false
+                visible = false
+                extendsFrom(implementation)
+                attributes {
+                    attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+                    attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, DocsType.SOURCES))
+                }
+            }
+        }
         dependencies {
             implementation project(':alfred-telemetry-solr:alfred-telemetry-solr-common')
+        }
+        java {
+            withJavadocJar()
+            withSourcesJar()
+        }
+
+        javadoc {
+            dependsOn(configurations.implementationSources)
+            source += configurations.implementationSources.collect {
+                zipTree(it).matching {
+                    include('**/*.java')
+                }
+            }
+            classpath += configurations.runtimeClasspath
+        }
+
+        sourcesJar {
+            dependsOn(configurations.implementationSources)
+            from(configurations.implementationSources.collect { zipTree(it) })
         }
     }
 
@@ -54,6 +87,8 @@ subprojects {
             publications {
                 mavenJava(MavenPublication) {
                     project.shadow.component(it)
+                    artifact sourcesJar
+                    artifact javadocJar
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'eu.xenit.docker-compose' version '5.1.1' apply false
+    id 'de.marcphilipp.nexus-publish' version '0.4.0' apply false
 }
 
 subprojects {

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
+apply plugin: 'de.marcphilipp.nexus-publish'
 
 publishing {
     publications {
@@ -30,17 +31,13 @@ publishing {
             }
         }
     }
+}
 
+nexusPublishing {
     repositories {
-        maven {
-            def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-            def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-
-            credentials {
-                username = project.hasProperty('publish_username') ? project.publish_username : ''
-                password = project.hasProperty('publish_password') ? project.publish_password : ''
-            }
+        sonatype {
+            username = project.hasProperty('publish_username') ? project.publish_username : ''
+            password = project.hasProperty('publish_password') ? project.publish_password : ''
         }
     }
 }


### PR DESCRIPTION
Publishing to sonatype with implicit staging repository creation is a bit wonky, sometimes it automatically creates multiple separate staging repositories
for one set of assets. This plugin should help avoiding that.