### PR TITLE
Removes transitive compile-time dependency on enterprise acs-packaging

### DIFF
--- a/alfred-telemetry-platform/build.gradle
+++ b/alfred-telemetry-platform/build.gradle
@@ -26,7 +26,7 @@ ext {
 }
 
 dependencies {
-    implementation enforcedPlatform("org.alfresco:acs-packaging:${alfrescoVersion}")
+    alfrescoProvided enforcedPlatform("org.alfresco:acs-packaging:${alfrescoVersion}")
 
     alfrescoProvided('org.alfresco:alfresco-repository')
 


### PR DESCRIPTION
Fixes #59 

The build was using `org.alfresco:acs-packaging` as an imported BOM, but there are no Alfresco-dependencies in `implementation`, only in `alfrescoProvided`. 

This PR moves the `enforcedPlatform(...)` BOM import also to `alfrescoProvided`, which removes the dependency from the `dependencyManagement` section from the published .pom.

