### PR TITLE
Alfresco 6.2.1 support

### DIFF
--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/care4alf/TicketMetricsMeterFilter.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/care4alf/TicketMetricsMeterFilter.java
@@ -1,14 +1,9 @@
 package eu.xenit.alfred.telemetry.binder.care4alf;
 
 import eu.xenit.alfred.telemetry.binder.TicketMetrics;
-import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Meter.Id;
-import io.micrometer.core.instrument.Tag;
-import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.config.MeterFilterReply;
-import java.util.List;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 /**
@@ -17,6 +12,9 @@ import javax.annotation.Nonnull;
 public class TicketMetricsMeterFilter implements MeterFilter {
 
     public final static String METRIC_CARE4ALF_NAME_TICKETS = "users.tickets";
+
+    private static final MeterFilter FILTER_IGNORE_EXP_STATUS =
+            MeterFilter.ignoreTags(TicketMetrics.METRIC_TAG_NAME_EXPIRATION_STATUS);
 
     @Override
     @Nonnull
@@ -28,14 +26,9 @@ public class TicketMetricsMeterFilter implements MeterFilter {
         if (!TicketMetrics.METRIC_TAG_VALUE_NON_EXPIRED.equals(expirationStatus)) {
             return id;
         }
-        Tags tags = removeTags(id.getTags(), TicketMetrics.METRIC_TAG_NAME_EXPIRATION_STATUS);
-        return new Meter.Id(
-                METRIC_CARE4ALF_NAME_TICKETS,
-                tags,
-                id.getBaseUnit(),
-                id.getDescription(),
-                id.getType()
-        );
+
+        id = FILTER_IGNORE_EXP_STATUS.map(id);
+        return id.withName(METRIC_CARE4ALF_NAME_TICKETS);
     }
 
     @Override
@@ -48,18 +41,5 @@ public class TicketMetricsMeterFilter implements MeterFilter {
         }
 
         return MeterFilterReply.NEUTRAL;
-    }
-
-    private static Tags removeTags(final List<Tag> tags, final String... tagKeys) {
-        List<Tag> filtered = tags.stream()
-                .filter(t -> {
-                    for (String tagKey : tagKeys) {
-                        if (t.getKey().equals(tagKey)) {
-                            return false;
-                        }
-                    }
-                    return true;
-                }).collect(Collectors.toList());
-        return Tags.of(filtered);
     }
 }

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/care4alf/TicketMetricsMeterFilter.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/care4alf/TicketMetricsMeterFilter.java
@@ -4,6 +4,7 @@ import eu.xenit.alfred.telemetry.binder.TicketMetrics;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Meter.Id;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.core.instrument.config.MeterFilterReply;
 import java.util.List;
@@ -27,9 +28,10 @@ public class TicketMetricsMeterFilter implements MeterFilter {
         if (!TicketMetrics.METRIC_TAG_VALUE_NON_EXPIRED.equals(expirationStatus)) {
             return id;
         }
+        Tags tags = removeTags(id.getTags(), TicketMetrics.METRIC_TAG_NAME_EXPIRATION_STATUS);
         return new Meter.Id(
                 METRIC_CARE4ALF_NAME_TICKETS,
-                removeTags(id.getTags(), TicketMetrics.METRIC_TAG_NAME_EXPIRATION_STATUS),
+                tags,
                 id.getBaseUnit(),
                 id.getDescription(),
                 id.getType()
@@ -48,8 +50,8 @@ public class TicketMetricsMeterFilter implements MeterFilter {
         return MeterFilterReply.NEUTRAL;
     }
 
-    private static List<Tag> removeTags(final List<Tag> tags, final String... tagKeys) {
-        return tags.stream()
+    private static Tags removeTags(final List<Tag> tags, final String... tagKeys) {
+        List<Tag> filtered = tags.stream()
                 .filter(t -> {
                     for (String tagKey : tagKeys) {
                         if (t.getKey().equals(tagKey)) {
@@ -58,5 +60,6 @@ public class TicketMetricsMeterFilter implements MeterFilter {
                     }
                     return true;
                 }).collect(Collectors.toList());
+        return Tags.of(filtered);
     }
 }

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/solr/sharding/SolrShardingMetricsContainer.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/solr/sharding/SolrShardingMetricsContainer.java
@@ -2,6 +2,7 @@ package eu.xenit.alfred.telemetry.binder.solr.sharding;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -17,7 +18,7 @@ import org.alfresco.repo.index.shard.ShardState;
 public class SolrShardingMetricsContainer {
 
     private ShardRegistry shardRegistry;
-    private HashMap<Floc, HashMap<Shard, HashSet<ShardState>>> rawData;
+    private Map<Floc, HashMap<Shard, HashSet<ShardState>>> rawData;
     private long lastRefresh;
     private long ttl; // how long before the raw data will be refreshed
 

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/config/CommonTagFilterFactory.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/config/CommonTagFilterFactory.java
@@ -1,9 +1,11 @@
 package eu.xenit.alfred.telemetry.config;
 
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Meter.Id;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.config.MeterFilterReply;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Hashtable;
@@ -38,18 +40,18 @@ public class CommonTagFilterFactory extends AbstractFactoryBean<MeterFilter> {
         return commonTagsIfNotExists(getCommonTags());
     }
 
-    public static MeterFilter commonTagsIfNotExists(Iterable<Tag> tags) {
+    public static MeterFilter commonTagsIfNotExists(Iterable<Tag> tagsToAdd) {
         return new MeterFilter() {
             @Override
             @Nonnull
             public Meter.Id map(@Nonnull Meter.Id id) {
-                Tags allTags = Tags.of(id.getTags());
-
-                StreamSupport.stream(tags.spliterator(), false)
-                        .filter(t -> id.getTag(t.getKey()) == null)
-                        .forEach(allTags::and);
-
-                return new Meter.Id(id.getName(), allTags, id.getBaseUnit(), id.getDescription(), id.getType());
+                Id ret = id;
+                for (Tag tagToAdd : tagsToAdd) {
+                    if (ret.getTag(tagToAdd.getKey()) == null) {
+                        ret = ret.withTag(tagToAdd);
+                    }
+                }
+                return ret;
             }
         };
     }

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/config/CommonTagFilterFactory.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/config/CommonTagFilterFactory.java
@@ -2,12 +2,11 @@ package eu.xenit.alfred.telemetry.config;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.config.MeterFilter;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
 import java.util.Hashtable;
-import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -44,11 +43,11 @@ public class CommonTagFilterFactory extends AbstractFactoryBean<MeterFilter> {
             @Override
             @Nonnull
             public Meter.Id map(@Nonnull Meter.Id id) {
-                List<Tag> allTags = new ArrayList<>(id.getTags());
+                Tags allTags = Tags.of(id.getTags());
 
                 StreamSupport.stream(tags.spliterator(), false)
                         .filter(t -> id.getTag(t.getKey()) == null)
-                        .forEach(allTags::add);
+                        .forEach(allTags::and);
 
                 return new Meter.Id(id.getName(), allTags, id.getBaseUnit(), id.getDescription(), id.getType());
             }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ subprojects {
         version += "-SNAPSHOT"
 
     ext {
-        micrometerVersion = '1.0.6'
+        micrometerVersion = '1.3.5'
         jvmExtrasVersion = '0.1.2'
 
         junitJupiterVersion = '5.4.2'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ subprojects {
         version += "-SNAPSHOT"
 
     ext {
-        micrometerVersion = '1.3.5'
+        micrometerVersion = '1.0.6'
         jvmExtrasVersion = '0.1.2'
 
         junitJupiterVersion = '5.4.2'

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,7 @@ include ':alfred-telemetry-solr'
 }
 
 include ':integration-tests'
-["52", "60", "61"].each { version ->
+["52", "60", "61", "62"].each { version ->
     include ":integration-tests:alfresco-community-${version}"
     include ":integration-tests:alfresco-enterprise-${version}"
 }


### PR DESCRIPTION
Closes #20

Including these changes, Alfred Telemetry seems to work on Alfresco 6.2.1.. 

There still is a Micrometer version conflict (Alfred Telemetry 1.0.6 vs Alfresco 1.3.5) for which we me might / should introduce a more pragmatic solution. 
When running Alfresco 6.2.1 now, there are two versions of the micrometer jar's in the `WEB-INF/lib` folder. As long as they're more or less compatible this workaround works fine. 