### PR TITLE
Remove dependency on JCenter repository

### DIFF
--- a/alfred-telemetry-solr/alfred-telemetry-solr-common/build.gradle
+++ b/alfred-telemetry-solr/alfred-telemetry-solr-common/build.gradle
@@ -9,8 +9,6 @@ java {
     withSourcesJar()
 }
 
-apply from: '../jcenter.gradle'
-
 dependencies {
     // Micrometer libraries.
     // API dependencies implementations are used by alfred-telemetry-solr4 and alfred-telemetry-solr6
@@ -22,5 +20,7 @@ dependencies {
     // compile against solr4 libraries
     alfrescoProvided "org.alfresco:alfresco-solr4:5.2.g:classes@jar"
     alfrescoProvided "org.alfresco:alfresco-solrclient:5.2.g"
-    alfrescoProvided "org.apache.solr:solr-core:4.10.3"
+    alfrescoProvided ("org.apache.solr:solr-core:4.10.3") {
+        exclude group: 'org.restlet.jee' // Only available in JCenter, not essential in this project.
+    }
 }

--- a/alfred-telemetry-solr/alfred-telemetry-solr4/build.gradle
+++ b/alfred-telemetry-solr/alfred-telemetry-solr4/build.gradle
@@ -10,11 +10,12 @@ java {
 }
 
 apply from: './overload.gradle'
-apply from: '../jcenter.gradle'
 
 
 dependencies {
-    alfrescoProvided "org.apache.solr:solr-core:${solrVersion}"
+    alfrescoProvided ("org.apache.solr:solr-core:${solrVersion}") {
+        exclude group: 'org.restlet.jee' // Only available in JCenter, not essential in this project.
+    }
     alfrescoProvided "org.alfresco:alfresco-solrclient:${alfrescoVersion}"
     alfrescoProvided "org.alfresco:alfresco-solr4:${alfrescoVersion}:classes@jar"
     alfrescoProvided "org.apache.tomcat:tomcat-catalina:7.0.92"

--- a/alfred-telemetry-solr/alfred-telemetry-solr6/build.gradle
+++ b/alfred-telemetry-solr/alfred-telemetry-solr6/build.gradle
@@ -10,10 +10,11 @@ java {
 }
 
 apply from: './overload.gradle'
-apply from: '../jcenter.gradle'
 
 dependencies {
-    alfrescoProvided "org.apache.solr:solr-core:${solrVersion}"
+    alfrescoProvided ("org.apache.solr:solr-core:${solrVersion}") {
+        exclude group: 'org.restlet.jee' // Only available in JCenter, not essential in this project.
+    }
     alfrescoProvided "org.alfresco:alfresco-search:${assVersion}"
 }
 

--- a/alfred-telemetry-solr/jcenter.gradle
+++ b/alfred-telemetry-solr/jcenter.gradle
@@ -1,8 +1,0 @@
-repositories {
-    jcenter {
-        mavenContent {
-            // Only allow artifacts with this groupID to be resolved from Jcenter
-            includeGroup 'org.restlet.jee'
-        }
-    }
-}


### PR DESCRIPTION
FYI: I considered working with:
```
    configurations.all {
        exclude group: 'org.restlet.jee'
    }
```

However IMO it's cleaner to make this more explicit, like it is in this PR. 