### PR TITLE
License metrics: rename the "max" metrics. 

### DIFF
--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/LicenseMetrics.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/LicenseMetrics.java
@@ -48,11 +48,11 @@ public class LicenseMetrics implements MeterBinder, ApplicationContextAware {
                 .description("Remaining days")
                 .tags("status", "remaining")
                 .register(registry);
-        Gauge.builder(METRIC_NAME_LICENSE + ".maxDocs", descriptorService, LicenseMetrics::getMaxDocs)
+        Gauge.builder(METRIC_NAME_LICENSE + ".docs.max", descriptorService, LicenseMetrics::getMaxDocs)
                 .description("Max docs")
                 .tags("status", "max")
                 .register(registry);
-        Gauge.builder(METRIC_NAME_LICENSE + ".maxUsers", descriptorService, LicenseMetrics::getMaxUsers)
+        Gauge.builder(METRIC_NAME_LICENSE + ".users.max", descriptorService, LicenseMetrics::getMaxUsers)
                 .description("Max users")
                 .tags("status", "max")
                 .register(registry);

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/LicenseMetrics.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/LicenseMetrics.java
@@ -48,11 +48,11 @@ public class LicenseMetrics implements MeterBinder, ApplicationContextAware {
                 .description("Remaining days")
                 .tags("status", "remaining")
                 .register(registry);
-        Gauge.builder(METRIC_NAME_LICENSE + ".docs", descriptorService, LicenseMetrics::getMaxDocs)
+        Gauge.builder(METRIC_NAME_LICENSE + ".maxDocs", descriptorService, LicenseMetrics::getMaxDocs)
                 .description("Max docs")
                 .tags("status", "max")
                 .register(registry);
-        Gauge.builder(METRIC_NAME_LICENSE + ".users", descriptorService, LicenseMetrics::getMaxUsers)
+        Gauge.builder(METRIC_NAME_LICENSE + ".maxUsers", descriptorService, LicenseMetrics::getMaxUsers)
                 .description("Max users")
                 .tags("status", "max")
                 .register(registry);

--- a/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/binder/LicenseMetricsTest.java
+++ b/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/binder/LicenseMetricsTest.java
@@ -72,7 +72,7 @@ public class LicenseMetricsTest {
     public void testNoLicenseDescriptor() {
         when(descriptorService.getLicenseDescriptor()).thenReturn(null);
         licenseMetrics.bindTo(meterRegistry);
-        assertThat(meterRegistry.get("license.maxDocs").gauge().value(), is(-1.0));
+        assertThat(meterRegistry.get("license.docs.max").gauge().value(), is(-1.0));
     }
 
     @Test
@@ -86,19 +86,19 @@ public class LicenseMetricsTest {
         assertThat(meterRegistry.get("license.valid").gauge().value(), is(0.0));
 
         when(licenseDescriptor.getMaxDocs()).thenReturn(100L);
-        assertThat(meterRegistry.get("license.maxDocs").tag("status", "max").gauge().value(), is(100.0));
+        assertThat(meterRegistry.get("license.docs.max").gauge().value(), is(100.0));
 
         when(licenseDescriptor.getMaxDocs()).thenReturn(null);
-        assertThat(meterRegistry.get("license.maxDocs").tag("status", "max").gauge().value(), is(-1.0));
+        assertThat(meterRegistry.get("license.docs.max").gauge().value(), is(-1.0));
 
         when(licenseDescriptor.getMaxUsers()).thenReturn(100L);
-        assertThat(meterRegistry.get("license.maxUsers").tag("status", "max").gauge().value(), is(100.0));
+        assertThat(meterRegistry.get("license.users.max").gauge().value(), is(100.0));
 
         when(repoUsage.getUsers()).thenReturn(3L);
         assertThat(meterRegistry.get("license.users").tag("status", "current").gauge().value(), is(3.0));
 
         when(licenseDescriptor.getMaxUsers()).thenReturn(null);
-        assertThat(meterRegistry.get("license.maxUsers").tag("status", "max").gauge().value(), is(-1.0));
+        assertThat(meterRegistry.get("license.users.max").gauge().value(), is(-1.0));
 
         when(licenseDescriptor.getRemainingDays()).thenReturn(100);
         assertThat(meterRegistry.get("license.days").tag("status", "remaining").gauge().value(), is(100.0));

--- a/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/binder/LicenseMetricsTest.java
+++ b/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/binder/LicenseMetricsTest.java
@@ -72,7 +72,7 @@ public class LicenseMetricsTest {
     public void testNoLicenseDescriptor() {
         when(descriptorService.getLicenseDescriptor()).thenReturn(null);
         licenseMetrics.bindTo(meterRegistry);
-        assertThat(meterRegistry.get("license.docs").tag("status", "max").gauge().value(), is(-1.0));
+        assertThat(meterRegistry.get("license.maxDocs").gauge().value(), is(-1.0));
     }
 
     @Test
@@ -86,19 +86,19 @@ public class LicenseMetricsTest {
         assertThat(meterRegistry.get("license.valid").gauge().value(), is(0.0));
 
         when(licenseDescriptor.getMaxDocs()).thenReturn(100L);
-        assertThat(meterRegistry.get("license.docs").tag("status", "max").gauge().value(), is(100.0));
+        assertThat(meterRegistry.get("license.maxDocs").tag("status", "max").gauge().value(), is(100.0));
 
         when(licenseDescriptor.getMaxDocs()).thenReturn(null);
-        assertThat(meterRegistry.get("license.docs").tag("status", "max").gauge().value(), is(-1.0));
+        assertThat(meterRegistry.get("license.maxDocs").tag("status", "max").gauge().value(), is(-1.0));
 
         when(licenseDescriptor.getMaxUsers()).thenReturn(100L);
-        assertThat(meterRegistry.get("license.users").tag("status", "max").gauge().value(), is(100.0));
+        assertThat(meterRegistry.get("license.maxUsers").tag("status", "max").gauge().value(), is(100.0));
 
         when(repoUsage.getUsers()).thenReturn(3L);
         assertThat(meterRegistry.get("license.users").tag("status", "current").gauge().value(), is(3.0));
 
         when(licenseDescriptor.getMaxUsers()).thenReturn(null);
-        assertThat(meterRegistry.get("license.users").tag("status", "max").gauge().value(), is(-1.0));
+        assertThat(meterRegistry.get("license.maxUsers").tag("status", "max").gauge().value(), is(-1.0));
 
         when(licenseDescriptor.getRemainingDays()).thenReturn(100);
         assertThat(meterRegistry.get("license.days").tag("status", "remaining").gauge().value(), is(100.0));

--- a/docs/README.md
+++ b/docs/README.md
@@ -264,9 +264,9 @@ Metrics provided
 | Name                                  | Available tags           | Comment                                    |
 | :------------------------------------ | :----------------------  | :----------------------------------------- |
 | license.valid                         |                          |                                            |
-| license.maxUsers                      |                          |                                            |
+| license.users.max                      |                          |                                            |
 | license.users                         |       status:[current]   | User needs to have logged in at least once |
-| license.maxDocs                       |                          |                                            |
+| license.docs.max                       |                          |                                            |
 | license.days                          |       status:[remaining] |                                            |
 | license.cluster.enabled               |                          |                                            |
 | license.encryption.enabled            |                          |                                            |

--- a/docs/README.md
+++ b/docs/README.md
@@ -261,16 +261,16 @@ The license metrics bindings will provide metrics about Alfresco license. Enterp
 
 Metrics provided
 
-| Name                                  | Available tags           | Comment |
-| :------------------------------------ | :----------------------- |         |
-| license.valid                         |                          |         |
-| license.users                         |       status:[max]       |         |
+| Name                                  | Available tags           | Comment                                    |
+| :------------------------------------ | :----------------------  | :----------------------------------------- |
+| license.valid                         |                          |                                            |
+| license.maxUsers                      |                          |                                            |
 | license.users                         |       status:[current]   | User needs to have logged in at least once |
-| license.docs                          |       status:[max]       |         |
-| license.days                          |       status:[remaining] |         |
-| license.cluster.enabled               |                          |         |
-| license.encryption.enabled            |                          |         |
-| license.heartbeat.enabled             |                          |         |
+| license.maxDocs                       |                          |                                            |
+| license.days                          |       status:[remaining] |                                            |
+| license.cluster.enabled               |                          |                                            |
+| license.encryption.enabled            |                          |                                            |
+| license.heartbeat.enabled             |                          |                                            |
 
 
 


### PR DESCRIPTION
Status tags make sense only if they can be summed together (not the case for "max").