### PR TITLE
Remove tag status for .max metrics.

### DIFF
--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/LicenseMetrics.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/LicenseMetrics.java
@@ -50,11 +50,9 @@ public class LicenseMetrics implements MeterBinder, ApplicationContextAware {
                 .register(registry);
         Gauge.builder(METRIC_NAME_LICENSE + ".docs.max", descriptorService, LicenseMetrics::getMaxDocs)
                 .description("Max docs")
-                .tags("status", "max")
                 .register(registry);
         Gauge.builder(METRIC_NAME_LICENSE + ".users.max", descriptorService, LicenseMetrics::getMaxUsers)
                 .description("Max users")
-                .tags("status", "max")
                 .register(registry);
         Gauge.builder(METRIC_NAME_LICENSE + ".users", repoAdminService, LicenseMetrics::getAuthorizedUsers)
                 .description("Authorized users")


### PR DESCRIPTION
Leftover from renaming of max metrics.
Will merge as admin.