### PR TITLE
#70 Manage maximum number of Prometheus requests with a Semaphore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ Version template:
  
 # Alfred Telemetry Changelog
 ## [0.5.2] - UNRELEASED
- 
+
+### Added
+* Configurable number of maximum prometheus scrape requests [#70]
+
+[#70]: https://github.com/xenit-eu/alfred-telemetry/pull/70 
 
 ## [0.5.1] - 2021-04-29
 

--- a/alfred-telemetry-platform/build.gradle
+++ b/alfred-telemetry-platform/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
     testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
     testImplementation "org.hamcrest:hamcrest-all:${hamcrestVersion}"
+    testImplementation "org.awaitility:awaitility:${awaitilityVersion}"
 
     testRuntimeOnly 'org.alfresco:alfresco-remote-api'
 }

--- a/alfred-telemetry-platform/docs/README.md
+++ b/alfred-telemetry-platform/docs/README.md
@@ -110,6 +110,13 @@ to present a [Prometheus scrape](https://prometheus.io/) with the appropriate fo
 > If the micrometer-registry-prometheus module is not available on the classpath, requests to the endpoint 
 > will result in a HTTP Status code 404
 
+Additional Prometheus configuration:
+
+```properties
+# The maximum number of concurrent requests the Prometheus endpoint should handle. Once the maximum number of 
+# requests is being processed, the response for new requests will have status code 503.
+alfred.telemetry.export.prometheus.max-requests=1
+```
 
 # Supported metrics
 

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/registry/prometheus/PrometheusConfig.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/registry/prometheus/PrometheusConfig.java
@@ -4,4 +4,13 @@ import eu.xenit.alfred.telemetry.registry.AbstractRegistryConfig;
 
 public class PrometheusConfig extends AbstractRegistryConfig {
 
+    private int maxRequests;
+
+    public int getMaxRequests() {
+        return maxRequests;
+    }
+
+    public void setMaxRequests(int maxRequests) {
+        this.maxRequests = maxRequests;
+    }
 }

--- a/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/alfresco-global.properties
+++ b/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/alfresco-global.properties
@@ -15,6 +15,7 @@ alfred.telemetry.export.jmx.enabled=true
 
 ## Micrometer Prometheus registry configuration
 alfred.telemetry.export.prometheus.enabled=true
+alfred.telemetry.export.prometheus.max-requests=1
 
 
 #### Alfresco integration configuration ####

--- a/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/context/registry-context.xml
+++ b/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/context/registry-context.xml
@@ -60,6 +60,7 @@
     <bean id="alfred-telemetry.PrometheusConfig"
             class="eu.xenit.alfred.telemetry.registry.prometheus.PrometheusConfig">
         <property name="enabled" value="${alfred.telemetry.export.prometheus.enabled}"/>
+        <property name="maxRequests" value="${alfred.telemetry.export.prometheus.max-requests}"/>
     </bean>
 
     <bean id="alfred-telemetry.PrometheusRegistryFactoryWrapper"

--- a/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/context/webscripts-context.xml
+++ b/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/context/webscripts-context.xml
@@ -14,6 +14,7 @@
             class="eu.xenit.alfred.telemetry.webscripts.PrometheusWebScript"
             parent="webscript">
         <constructor-arg ref="meterRegistry"/>
+        <constructor-arg ref="alfred-telemetry.PrometheusConfig"/>
     </bean>
 
     <bean id="webscript.eu.xenit.alfred.telemetry.webscripts.alfred-metrics.get"

--- a/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/webscripts/PrometheusWebScriptTest.java
+++ b/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/webscripts/PrometheusWebScriptTest.java
@@ -1,0 +1,66 @@
+package eu.xenit.alfred.telemetry.webscripts;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import eu.xenit.alfred.telemetry.registry.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.extensions.webscripts.WebScriptException;
+import org.springframework.extensions.webscripts.WebScriptRequest;
+import org.springframework.extensions.webscripts.WebScriptResponse;
+
+@ExtendWith(MockitoExtension.class)
+class PrometheusWebScriptTest {
+
+    @Mock
+    private PrometheusMeterRegistry registry;
+
+    @Test
+    void execute_maxRequestsReached() {
+        PrometheusWebScript webScript = initWebScript(1);
+
+        when(registry.scrape()).thenAnswer(answer -> {
+            await().forever().until(() -> false);
+            return "dummy";
+        });
+
+        Runnable runnable = () -> {
+            WebScriptRequest request = mock(WebScriptRequest.class);
+            WebScriptResponse response = mock(WebScriptResponse.class);
+            try {
+                webScript.execute(request, response);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        };
+        Thread thread = new Thread(runnable);
+        thread.start();
+
+        WebScriptRequest request = mock(WebScriptRequest.class);
+        WebScriptResponse response = mock(WebScriptResponse.class);
+
+        WebScriptException e = assertThrows(WebScriptException.class, () -> webScript.execute(request, response));
+        assertThat(e.getStatus(), is(equalTo(503)));
+
+        thread.interrupt();
+    }
+
+    private PrometheusWebScript initWebScript(int maxRequests) {
+        PrometheusConfig config = new PrometheusConfig();
+        config.setMaxRequests(maxRequests);
+        return new PrometheusWebScript(registry, config);
+
+    }
+
+}

--- a/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/webscripts/PrometheusWebScriptTest.java
+++ b/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/webscripts/PrometheusWebScriptTest.java
@@ -6,12 +6,17 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import eu.xenit.alfred.telemetry.registry.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -23,8 +28,25 @@ import org.springframework.extensions.webscripts.WebScriptResponse;
 @ExtendWith(MockitoExtension.class)
 class PrometheusWebScriptTest {
 
+    private static final String TEST_SCRAPE_TEXT = "dummy";
+
     @Mock
     private PrometheusMeterRegistry registry;
+
+    @Test
+    void execute() throws IOException {
+        PrometheusWebScript webScript = initWebScript(1);
+        when(registry.scrape()).thenReturn(TEST_SCRAPE_TEXT);
+
+        WebScriptRequest request = mock(WebScriptRequest.class);
+        WebScriptResponse response = mock(WebScriptResponse.class);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        when(response.getOutputStream()).thenReturn(out);
+
+        webScript.execute(request, response);
+        verify(response).setStatus(200);
+        assertThat(out.toString("UTF-8"), is(equalTo(TEST_SCRAPE_TEXT)));
+    }
 
     @Test
     void execute_maxRequestsReached() {
@@ -32,10 +54,10 @@ class PrometheusWebScriptTest {
 
         when(registry.scrape()).thenAnswer(answer -> {
             await().forever().until(() -> false);
-            return "dummy";
+            return TEST_SCRAPE_TEXT;
         });
 
-        Runnable runnable = () -> {
+        Runnable firstHttpRequest = () -> {
             WebScriptRequest request = mock(WebScriptRequest.class);
             WebScriptResponse response = mock(WebScriptResponse.class);
             try {
@@ -44,16 +66,20 @@ class PrometheusWebScriptTest {
                 throw new UncheckedIOException(e);
             }
         };
-        Thread thread = new Thread(runnable);
-        thread.start();
 
-        WebScriptRequest request = mock(WebScriptRequest.class);
-        WebScriptResponse response = mock(WebScriptResponse.class);
+        Runnable secondHttpRequest = () -> {
+            WebScriptRequest request = mock(WebScriptRequest.class);
+            WebScriptResponse response = mock(WebScriptResponse.class);
+            WebScriptException e = assertThrows(WebScriptException.class, () -> webScript.execute(request, response));
+            assertThat(e.getStatus(), is(equalTo(503)));
+        };
 
-        WebScriptException e = assertThrows(WebScriptException.class, () -> webScript.execute(request, response));
-        assertThat(e.getStatus(), is(equalTo(503)));
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        executorService.submit(firstHttpRequest);
+        Future<?> future = executorService.submit(secondHttpRequest);
 
-        thread.interrupt();
+        await().until(future::isDone);
+        executorService.shutdownNow();
     }
 
     private PrometheusWebScript initWebScript(int maxRequests) {

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ allprojects {
         junitJupiterVersion = '5.4.2'
         mockitoVersion = '2.27.0'
         hamcrestVersion = '1.3'
+        awaitilityVersion = '4.1.0'
         restAssuredVersion = '4.0.0'
     }
 


### PR DESCRIPTION
Fixes #70 

Should prevent threads from stacking up when an underlying problem causes Prometheus HTTP requests to take a long time. 