### PR TITLE
Support more flexible Graphite step duration configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Version template:
 
 ## [0.7.2] - UNRELEASED
 
+### Added
+* Support more flexible Graphite step duration configuration
+
 
 ## [0.7.1] - 2021-07-12
 

--- a/alfred-telemetry-platform/docs/README.md
+++ b/alfred-telemetry-platform/docs/README.md
@@ -83,8 +83,9 @@ alfred.telemetry.export.graphite.port=2004
 Additional Graphite configuration:
 
 ```properties
-# The interval at which metrics are sent to Graphite, in seconds.
-alfred.telemetry.export.graphite.step=5
+# The interval at which metrics are sent to Graphite. The duration can be provided in a simple format (5s, 1m, ...)
+# or in an ISO8601 compliant format (PT5S, PT1M, ... see java.time.Duration#parse(CharSequence))
+alfred.telemetry.export.graphite.step=5s
 
 # Applies the tag value of a set of common tags as a prefix
 alfred.telemetry.export.graphite.tags-as-prefix=application,host

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/TicketMetrics.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/TicketMetrics.java
@@ -14,7 +14,7 @@ public class TicketMetrics implements MeterBinder {
     public final static String METRIC_TAG_VALUE_EXPIRED = "expired";
     public final static String METRIC_TAG_VALUE_NON_EXPIRED = "valid";
 
-    private TicketComponent ticketComponent;
+    private final TicketComponent ticketComponent;
 
     public TicketMetrics(TicketComponent ticketComponent) {
         this.ticketComponent = ticketComponent;
@@ -38,7 +38,7 @@ public class TicketMetrics implements MeterBinder {
     }
 
     private static long getExpiredTicketsCount(final TicketComponent ticketComponent) {
-        return ticketComponent.getUsersWithTickets(false).size()
+        return (long) ticketComponent.getUsersWithTickets(false).size()
                 - ticketComponent.getUsersWithTickets(true).size();
     }
 }

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/registry/graphite/GraphiteConfig.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/registry/graphite/GraphiteConfig.java
@@ -1,7 +1,9 @@
 package eu.xenit.alfred.telemetry.registry.graphite;
 
 import eu.xenit.alfred.telemetry.registry.AbstractRegistryConfig;
+import eu.xenit.alfred.telemetry.util.DurationUtil;
 import eu.xenit.alfred.telemetry.util.StringUtils;
+import java.time.Duration;
 import java.util.List;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
@@ -9,7 +11,7 @@ public class GraphiteConfig extends AbstractRegistryConfig {
 
     private String host;
     private int port;
-    private int step;
+    private Duration step;
     private List<String> tagsAsPrefix;
 
     public String getHost() {
@@ -28,12 +30,12 @@ public class GraphiteConfig extends AbstractRegistryConfig {
         this.port = port;
     }
 
-    public int getStep() {
+    public Duration getStep() {
         return step;
     }
 
-    public void setStep(int step) {
-        this.step = step;
+    public void setStep(String step) {
+        this.step = DurationUtil.parseDuration(step);
     }
 
     public List<String> getTagsAsPrefix() {

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/registry/graphite/GraphiteRegistryFactory.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/registry/graphite/GraphiteRegistryFactory.java
@@ -33,7 +33,7 @@ public class GraphiteRegistryFactory implements RegistryFactory {
             @Override
             @Nonnull
             public Duration step() {
-                return Duration.ofSeconds(config.getStep());
+                return config.getStep();
             }
 
             @Override

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/util/DurationUtil.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/util/DurationUtil.java
@@ -1,0 +1,86 @@
+package eu.xenit.alfred.telemetry.util;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.util.StringUtils;
+
+/**
+ * Inspiration: https://github.com/spring-projects/spring-boot/blob/47516b50c39bd6ea924a1f6720ce6d4a71088651/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/convert/DurationStyle.java
+ */
+public class DurationUtil {
+
+    private DurationUtil() {
+        // private ctor to hide implicit public one
+    }
+
+    public static Duration parseDuration(String duration) {
+        for (DurationParser parser : DurationParser.values()) {
+            Matcher matcher = parser.getPattern().matcher(duration);
+            if (matcher.matches()) {
+                return parser.getConverter().apply(matcher);
+            }
+        }
+
+        throw new IllegalArgumentException("'" + duration + "' is not a valid duration");
+    }
+
+    enum DurationParser {
+        SIMPLE("^([+-]?\\d+)([a-zA-Z]{0,2})$", matcher -> {
+            return Duration.of(Long.parseLong(matcher.group(1)), suffixToUnit(matcher.group(2)));
+        }),
+        ISO8601("^[+-]?P.*$", matcher -> {
+            return Duration.parse(matcher.group());
+        });
+
+        private final Pattern pattern;
+        private final Function<Matcher, Duration> converter;
+
+        DurationParser(String pattern, Function<Matcher, Duration> converter) {
+            this.pattern = Pattern.compile(pattern);
+            this.converter = converter;
+        }
+
+        public Pattern getPattern() {
+            return pattern;
+        }
+
+        public Function<Matcher, Duration> getConverter() {
+            return converter;
+        }
+
+        private static ChronoUnit suffixToUnit(String suffix) {
+            return suffixToUnit(suffix, ChronoUnit.MILLIS);
+        }
+
+        private static ChronoUnit suffixToUnit(String suffix, ChronoUnit defaultUnit) {
+            if (!StringUtils.hasLength(suffix)) {
+                return defaultUnit;
+            }
+
+            final String suffixLowerCase = suffix.trim().toLowerCase();
+
+            switch (suffixLowerCase) {
+                case "ns":
+                    return ChronoUnit.NANOS;
+                case "us":
+                    return ChronoUnit.MICROS;
+                case "ms":
+                    return ChronoUnit.MILLIS;
+                case "s":
+                    return ChronoUnit.SECONDS;
+                case "m":
+                    return ChronoUnit.MINUTES;
+                case "h":
+                    return ChronoUnit.HOURS;
+                case "d":
+                    return ChronoUnit.DAYS;
+                default:
+                    throw new IllegalArgumentException("Unrecognized time suffix: '" + suffix + "'");
+            }
+
+        }
+    }
+}

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/util/DurationUtil.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/util/DurationUtil.java
@@ -28,12 +28,10 @@ public class DurationUtil {
     }
 
     enum DurationParser {
-        SIMPLE("^([+-]?\\d+)([a-zA-Z]{0,2})$", matcher -> {
-            return Duration.of(Long.parseLong(matcher.group(1)), suffixToUnit(matcher.group(2)));
-        }),
-        ISO8601("^[+-]?P.*$", matcher -> {
-            return Duration.parse(matcher.group());
-        });
+        SIMPLE("^([+-]?\\d+)([a-zA-Z]{0,2})$",
+                matcher -> Duration.of(Long.parseLong(matcher.group(1)), suffixToUnit(matcher.group(2)))),
+        ISO8601("^[+-]?P.*$",
+                matcher -> Duration.parse(matcher.group()));
 
         private final Pattern pattern;
         private final Function<Matcher, Duration> converter;

--- a/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/alfresco-global.properties
+++ b/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/alfresco-global.properties
@@ -7,7 +7,7 @@ alfred.telemetry.export.simple.enabled=true
 alfred.telemetry.export.graphite.enabled=true
 alfred.telemetry.export.graphite.host=localhost
 alfred.telemetry.export.graphite.port=2004
-alfred.telemetry.export.graphite.step=5
+alfred.telemetry.export.graphite.step=5s
 alfred.telemetry.export.graphite.tags-as-prefix=application,host
 
 ## Micrometer JMX registry configuration

--- a/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/registry/graphite/GraphiteConfigTest.java
+++ b/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/registry/graphite/GraphiteConfigTest.java
@@ -1,0 +1,21 @@
+package eu.xenit.alfred.telemetry.registry.graphite;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class GraphiteConfigTest {
+
+    @Test
+    void setStep() {
+        GraphiteConfig config = new GraphiteConfig();
+        config.setStep("10s");
+
+        assertThat(config.getStep(), is(equalTo(Duration.ofSeconds(10))));
+
+    }
+
+}

--- a/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/util/DurationUtilTest.java
+++ b/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/util/DurationUtilTest.java
@@ -1,0 +1,49 @@
+package eu.xenit.alfred.telemetry.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class DurationUtilTest {
+
+    @Test
+    void simpleDuration() {
+        assertThat(DurationUtil.parseDuration("2ns"), is(equalTo(Duration.ofNanos(2))));
+        assertThat(DurationUtil.parseDuration("2NS"), is(equalTo(Duration.ofNanos(2))));
+        assertThat(DurationUtil.parseDuration("3us"), is(equalTo(Duration.ofNanos(3000))));
+        assertThat(DurationUtil.parseDuration("4ms"), is(equalTo(Duration.ofMillis(4))));
+        assertThat(DurationUtil.parseDuration("11s"), is(equalTo(Duration.ofSeconds(11))));
+        assertThat(DurationUtil.parseDuration("11S"), is(equalTo(Duration.ofSeconds(11))));
+        assertThat(DurationUtil.parseDuration("101m"), is(equalTo(Duration.ofMinutes(101))));
+        assertThat(DurationUtil.parseDuration("1h"), is(equalTo(Duration.ofHours(1))));
+        assertThat(DurationUtil.parseDuration("3d"), is(equalTo(Duration.ofDays(3))));
+    }
+
+    @Test
+    void simpleDuration_invalidNumber() {
+        assertThrows(IllegalArgumentException.class, () -> DurationUtil.parseDuration("1.0s"));
+        assertThrows(IllegalArgumentException.class, () -> DurationUtil.parseDuration("1,0s"));
+    }
+
+    @Test
+    void simpleDuration_defaultSuffix() {
+        assertThat(DurationUtil.parseDuration("40"), is(equalTo(Duration.ofMillis(40))));
+    }
+
+    @Test
+    void simpleDuration_invalidSuffix() {
+        assertThrows(IllegalArgumentException.class, () -> DurationUtil.parseDuration("1ps"));
+    }
+
+    @Test
+    void iso6801Duration() {
+        assertThat(DurationUtil.parseDuration("PT0.005S"), is(equalTo(Duration.ofMillis(5))));
+        assertThat(DurationUtil.parseDuration("PT1S"), is(equalTo(Duration.ofSeconds(1))));
+        assertThat(DurationUtil.parseDuration("PT15M"), is(equalTo(Duration.ofMinutes(15))));
+    }
+
+}

--- a/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/webscripts/console/AdminConsoleWebScriptTest.java
+++ b/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/webscripts/console/AdminConsoleWebScriptTest.java
@@ -161,7 +161,7 @@ class AdminConsoleWebScriptTest {
     private Matcher<Map<String, String>> isValidGraphiteConfig() {
         return allOf(
                 hasEntry(is("alfred.telemetry.export.graphite.enabled"), isBoolean()),
-                hasEntry(is("alfred.telemetry.export.graphite.step"), isInteger()),
+                hasEntry(is("alfred.telemetry.export.graphite.step"), not(isEmptyString())),
                 hasEntry(is("alfred.telemetry.export.graphite.host"), not(isEmptyString())),
                 hasEntry(is("alfred.telemetry.export.graphite.port"), isInteger()),
                 hasKey(is("alfred.telemetry.export.graphite.tags-as-prefix"))


### PR DESCRIPTION
And most important: re-usable `DurationUtil` class, which can be used for future duration configuration too. 