### PR TITLE
BREAKING: stop embedding 'micrometer-core' and 'micrometer-jvm-extras'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Version template:
 ## [0.7.2] - UNRELEASED
 
 ### Fixed
-* Bug apearring when tracker is explicitelly disabled [#125]
+* Fixes bug when tracker is explicitly disabled [#125]
 
 [#125]: https://github.com/xenit-eu/alfred-telemetry/pull/125
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,15 @@ Version template:
 
 ## [0.7.2] - UNRELEASED
 
+### BREAKING
+
+* Alfred Telemetry declares `micrometer-core` and `micrometer-jvm-extras` as a provided-dependency. See [#129]
+
 ### Fixed
 * Fixes bug when tracker is explicitly disabled [#125]
 
 [#125]: https://github.com/xenit-eu/alfred-telemetry/pull/125
+[#129]: https://github.com/xenit-eu/alfred-telemetry/pull/129
 
 ### Added
 * Support more flexible Graphite step duration configuration

--- a/alfred-telemetry-platform/README.md
+++ b/alfred-telemetry-platform/README.md
@@ -27,9 +27,11 @@ used to build an Alfresco docker image with Alfred Telemetry installed:
 ```groovy
 // Alfresco Simple Module: 
 alfrescoSM "eu.xenit.alfred.telemetry:alfred-telemetry-platform:${last-version}"
+
 // Alfresco Module Package:
 alfrescoAmp "eu.xenit.alfred.telemetry:alfred-telemetry-platform:${last-version}@amp"
 ```
+
 
 ### Maven
 
@@ -52,13 +54,30 @@ in your distribution:
 </dependency>
 ```
 
+### BREAKING CHANGE IN 0.8
+
+Starting from Alfred Telemetry 0.8, Alfred Telemetry assumes the micrometer dependency is provided by Alfresco.
+This change avoids multiple versions of micrometer on the classpath and Alfred Telemetry does not need
+to split up releases for different Alfresco versions and editions.
+
+* Alfresco Enterprise ships with micrometer, starting from Alfresco v6.1.
+* Alfresco Community and Alfresco Enterprise < v6.1 do NOT have the required dependencies installed.
+
+In the latter case, you need to add the dependencies yourself:
+
+```groovy
+alfrescoSM "io.micrometer:micrometer-core:${micrometerVersion}"
+alfrescoSM "io.github.mweirauch:micrometer-jvm-extras:${jvmExtrasVersion}"
+```
+
 ### Manual download and install
 Please consult the official Alfresco documentation on how to install Simple Modules and Module Packages manually.
 
 ### Supported Alfresco versions
 
-Alfred Telemetry is systematically integration tested against Alfresco 5.2, 6.0, 6.1 and 6.2.
-Furthermore the extension is also known to work on Alfresco 5.0 and 5.1.
+Alfred Telemetry is systematically integration tested against:
+* Alfresco Enterprise 5.2, 6.0, 6.1, 6.2 and 7.0
+* Alfresco Community 5.2, 6.0, 6.1, 6.2 and 7.0
 
 
 ## Configuration
@@ -66,7 +85,7 @@ Furthermore the extension is also known to work on Alfresco 5.0 and 5.1.
 By default, Alfred Telemetry exposes all metrics on
 [the `alfresco/s/alfred/telemetry/metrics` endpoint](docs/README.md#metrics-endpoint). If
 metrics should be exported to a specific monitoring system, the corresponding
-`micrometer-registry-${monitoring-system}` should be included in the classpath of Alfresco. For a detailed
+`micrometer-registry-${monitoring-system}` dependency should be included in the classpath of Alfresco. For a detailed
 description have a look at the [relevant documentation](docs/README.md#supported-monitoring-systems).
 
 Once the desired monitoring systems are configured, out of the box metrics are available and custom

--- a/alfred-telemetry-platform/build.gradle
+++ b/alfred-telemetry-platform/build.gradle
@@ -37,10 +37,10 @@ dependencies {
         transitive = false
     }
 
-    implementation("io.micrometer:micrometer-core:${micrometerVersion}") {
+    alfrescoProvided("io.micrometer:micrometer-core:${micrometerVersion}") {
         exclude group: "org.slf4j", module: "*"
     }
-    implementation("io.github.mweirauch:micrometer-jvm-extras:${jvmExtrasVersion}") {
+    alfrescoProvided("io.github.mweirauch:micrometer-jvm-extras:${jvmExtrasVersion}") {
         exclude group: "org.slf4j", module: "*"
     }
 
@@ -53,6 +53,7 @@ dependencies {
     testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
     testImplementation "org.hamcrest:hamcrest-all:${hamcrestVersion}"
     testImplementation "org.awaitility:awaitility:${awaitilityVersion}"
+    testImplementation "org.assertj:assertj-core:${assertjVersion}"
 
     testRuntimeOnly 'org.alfresco:alfresco-remote-api'
 }

--- a/alfred-telemetry-platform/build.gradle
+++ b/alfred-telemetry-platform/build.gradle
@@ -53,7 +53,6 @@ dependencies {
     testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
     testImplementation "org.hamcrest:hamcrest-all:${hamcrestVersion}"
     testImplementation "org.awaitility:awaitility:${awaitilityVersion}"
-    testImplementation "org.assertj:assertj-core:${assertjVersion}"
 
     testRuntimeOnly 'org.alfresco:alfresco-remote-api'
 }

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/MeterBinderRegistrar.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/MeterBinderRegistrar.java
@@ -29,10 +29,10 @@ public class MeterBinderRegistrar implements InitializingBean, ApplicationContex
     private Properties properties = new Properties();
 
     /* DEPENDENCIES */
-    private MeterRegistry meterRegistry;
+    private final MeterRegistry meterRegistry;
     private ApplicationContext ctx;
 
-    private List<EventTriggeredMeterBinder> eventTriggeredMeterBinders = new ArrayList<>();
+    private final List<EventTriggeredMeterBinder> eventTriggeredMeterBinders = new ArrayList<>();
 
     public MeterBinderRegistrar(MeterRegistry meterRegistry) {
         this.meterRegistry = meterRegistry;
@@ -99,7 +99,7 @@ public class MeterBinderRegistrar implements InitializingBean, ApplicationContex
         return enabled;
     }
 
-    private String getEnabledPropertyKey(final MeterBinder binder) {
+    public static String getPropertyKey(final MeterBinder binder) {
         String binderName = null;
         if (binder instanceof NamedMeterBinder) {
             binderName = ((NamedMeterBinder) binder).getName();
@@ -108,11 +108,11 @@ public class MeterBinderRegistrar implements InitializingBean, ApplicationContex
             binderName = getMeterNameFromClass(binder.getClass());
         }
 
-        return getBinderPropertyPrefix() + binderName + PROP_BINDER_SUFFIX_ENABLED;
+        return PROP_BINDER_PREFIX + binderName;
     }
 
-    protected String getBinderPropertyPrefix() {
-        return PROP_BINDER_PREFIX;
+    public static String getEnabledPropertyKey(final MeterBinder binder) {
+        return getPropertyKey(binder) + PROP_BINDER_SUFFIX_ENABLED;
     }
 
     static String getMeterNameFromClass(Class<?> clazz) {

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/ProcessMetrics.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/ProcessMetrics.java
@@ -4,13 +4,20 @@ import io.github.mweirauch.micrometer.jvm.extras.ProcessMemoryMetrics;
 import io.github.mweirauch.micrometer.jvm.extras.ProcessThreadMetrics;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
+
 import javax.annotation.Nonnull;
 
 public class ProcessMetrics implements MeterBinder {
 
     @Override
     public void bindTo(@Nonnull MeterRegistry registry) {
-        new ProcessThreadMetrics().bindTo(registry);
-        new ProcessMemoryMetrics().bindTo(registry);
+        try {
+            new ProcessThreadMetrics().bindTo(registry);
+            new ProcessMemoryMetrics().bindTo(registry);
+        } catch (NoClassDefFoundError err) {
+            String msg = String.format("Missing dependency 'io.github.mweirauch:micrometer-jvm-extras'" +
+                    " or disable binder with '%s=false'", MeterBinderRegistrar.getEnabledPropertyKey(this));
+            throw new RuntimeException(msg, err);
+        }
     }
 }

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/clustering/ClusteringMetricsBeanPostProcessor.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/binder/clustering/ClusteringMetricsBeanPostProcessor.java
@@ -1,5 +1,6 @@
 package eu.xenit.alfred.telemetry.binder.clustering;
 
+import eu.xenit.alfred.telemetry.util.MicrometerModules;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -20,7 +21,9 @@ public class ClusteringMetricsBeanPostProcessor implements BeanDefinitionRegistr
 
     @Override
     public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry beanDefinitionRegistry) throws BeansException {
-        createClusteringMetricsBean(beanDefinitionRegistry);
+        if (MicrometerModules.isMicrometerOnClasspath()) {
+            createClusteringMetricsBean(beanDefinitionRegistry);
+        }
     }
 
     private void createClusteringMetricsBean(BeanDefinitionRegistry beanDefinitionRegistry) {

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/registry/MeterRegistryFactoryBean.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/registry/MeterRegistryFactoryBean.java
@@ -1,5 +1,6 @@
 package eu.xenit.alfred.telemetry.registry;
 
+import eu.xenit.alfred.telemetry.util.MicrometerModules;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
 import javax.annotation.Nonnull;
@@ -19,6 +20,12 @@ public class MeterRegistryFactoryBean extends AbstractFactoryBean<MeterRegistry>
     @Override
     @Nonnull
     protected MeterRegistry createInstance() {
+
+        MicrometerModules.Version version = MicrometerModules.getMicrometerCoreVersion();
+        if (version == null) {
+            throw new RuntimeException("Alfred Telemetry is missing required dependency 'io.micrometer:micrometer-core'");
+        }
+
         return Metrics.globalRegistry;
     }
 }

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/registry/RegistryFactoryWrapper.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/registry/RegistryFactoryWrapper.java
@@ -1,7 +1,7 @@
 package eu.xenit.alfred.telemetry.registry;
 
-import eu.xenit.alfred.telemetry.util.VersionUtil;
-import eu.xenit.alfred.telemetry.util.VersionUtil.Version;
+import eu.xenit.alfred.telemetry.util.MicrometerModules;
+import eu.xenit.alfred.telemetry.util.MicrometerModules.Version;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.util.ClassUtils;
 
@@ -34,7 +34,7 @@ public interface RegistryFactoryWrapper {
     RegistryFactory getRegistryFactory();
 
     default Version getRegistryVersion() {
-        return VersionUtil.getMicrometerModuleVersion(getModuleName());
+        return MicrometerModules.getMicrometerModuleVersion(getModuleName());
     }
 
     /**

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/registry/RegistryRegistrar.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/registry/RegistryRegistrar.java
@@ -3,8 +3,8 @@ package eu.xenit.alfred.telemetry.registry;
 
 import eu.xenit.alfred.telemetry.MeterRegistryCustomizer;
 import eu.xenit.alfred.telemetry.util.LambdaSafe;
-import eu.xenit.alfred.telemetry.util.VersionUtil;
-import eu.xenit.alfred.telemetry.util.VersionUtil.Version;
+import eu.xenit.alfred.telemetry.util.MicrometerModules;
+import eu.xenit.alfred.telemetry.util.MicrometerModules.Version;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
@@ -53,7 +53,7 @@ public class RegistryRegistrar implements InitializingBean, ApplicationContextAw
             return;
         }
 
-        final Version coreVersion = VersionUtil.getMicrometerCoreVersion();
+        final Version coreVersion = MicrometerModules.getMicrometerCoreVersion();
         final Version registryVersion = factoryWrapper.getRegistryVersion();
         if (coreVersion != null && registryVersion != null && !coreVersion.isCompatible(registryVersion)) {
             LOGGER.warn(

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/registry/simple/SimpleRegistryFactoryWrapper.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/registry/simple/SimpleRegistryFactoryWrapper.java
@@ -1,10 +1,10 @@
 package eu.xenit.alfred.telemetry.registry.simple;
 
-import static eu.xenit.alfred.telemetry.util.VersionUtil.MODULE_MICROMETER_CORE;
+import static eu.xenit.alfred.telemetry.util.MicrometerModules.MODULE_MICROMETER_CORE;
 
 import eu.xenit.alfred.telemetry.registry.RegistryFactory;
 import eu.xenit.alfred.telemetry.registry.RegistryFactoryWrapper;
-import eu.xenit.alfred.telemetry.util.VersionUtil;
+import eu.xenit.alfred.telemetry.util.MicrometerModules;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public class SimpleRegistryFactoryWrapper implements RegistryFactoryWrapper {
@@ -30,7 +30,7 @@ public class SimpleRegistryFactoryWrapper implements RegistryFactoryWrapper {
      * Micrometer core module.
      *
      * @return the name of the Micrometer core module which includes the {@link SimpleMeterRegistry}, being {@link
-     * VersionUtil#MODULE_MICROMETER_CORE}
+     * MicrometerModules#MODULE_MICROMETER_CORE}
      */
     @Override
     public String getModuleName() {

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/service/MicrometerOnClasspathDetector.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/service/MicrometerOnClasspathDetector.java
@@ -1,0 +1,22 @@
+package eu.xenit.alfred.telemetry.service;
+
+import eu.xenit.alfred.telemetry.util.MicrometerModules;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+
+public class MicrometerOnClasspathDetector implements BeanDefinitionRegistryPostProcessor {
+
+    @Override
+    public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry beanDefinitionRegistry) throws BeansException {
+        if (!MicrometerModules.isMicrometerOnClasspath()) {
+            throw new RuntimeException("Required dependency 'io.micrometer:micrometer-core' is not found on the classpath!");
+        }
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+
+    }
+}

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/util/MicrometerModules.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/util/MicrometerModules.java
@@ -1,23 +1,32 @@
 package eu.xenit.alfred.telemetry.util;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.Properties;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import eu.xenit.alfred.telemetry.webscripts.PrometheusWebScript;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.util.ClassUtils;
 
-public class VersionUtil {
+public class MicrometerModules {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(VersionUtil.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MicrometerModules.class);
 
     public static final String MODULE_MICROMETER_CORE = "micrometer-core";
 
-    private VersionUtil() {
+    private MicrometerModules() {
         // private ctor to hide implicit public one
+    }
+
+    public static boolean isMicrometerOnClasspath() {
+        return ClassUtils.isPresent("io.micrometer.core.instrument.Meter",
+                MicrometerModules.class.getClassLoader());
     }
 
     public static Version getMicrometerCoreVersion() {
@@ -42,6 +51,9 @@ public class VersionUtil {
             return extractVersionFromResource(
                     new PathMatchingResourcePatternResolver()
                             .getResource("classpath:/META-INF/" + moduleName + ".properties"));
+        } catch (FileNotFoundException fileNotFoundException) {
+            // micrometer not on the classpath
+            return null;
         } catch (IOException e) {
             LOGGER.warn("Unable to retrieve the version of module '{}'", moduleName, e);
             return null;

--- a/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/webscripts/console/AdminConsoleWebScript.java
+++ b/alfred-telemetry-platform/src/main/java/eu/xenit/alfred/telemetry/webscripts/console/AdminConsoleWebScript.java
@@ -1,7 +1,7 @@
 package eu.xenit.alfred.telemetry.webscripts.console;
 
 import com.google.common.annotations.VisibleForTesting;
-import eu.xenit.alfred.telemetry.util.VersionUtil;
+import eu.xenit.alfred.telemetry.util.MicrometerModules;
 import eu.xenit.alfred.telemetry.webscripts.console.AdminConsoleWebscriptResponseModel.AlfredTelemetryModule;
 import eu.xenit.alfred.telemetry.webscripts.console.AdminConsoleWebscriptResponseModel.TelemetryBinderConfigModel;
 import eu.xenit.alfred.telemetry.webscripts.console.AdminConsoleWebscriptResponseModel.TelemetryDependencyModel;
@@ -26,7 +26,6 @@ import org.springframework.extensions.webscripts.DeclarativeWebScript;
 import org.springframework.extensions.webscripts.Status;
 import org.springframework.extensions.webscripts.WebScriptRequest;
 import org.springframework.extensions.webscripts.WebScriptResponse;
-import org.springframework.util.StringUtils;
 
 public class AdminConsoleWebScript extends DeclarativeWebScript {
 
@@ -81,7 +80,7 @@ public class AdminConsoleWebScript extends DeclarativeWebScript {
 
     private Map<String, TelemetryDependencyModel> getDependenciesModel() {
         return Stream.of(
-                    new TelemetryDependencyModel("micrometer", VersionUtil.getMicrometerCoreVersion().toString())
+                    new TelemetryDependencyModel("micrometer", MicrometerModules.getMicrometerCoreVersion().toString())
             ).collect(Collectors.toMap(TelemetryDependencyModel::getId, Function.identity()));
     }
 

--- a/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/context/binder-context.xml
+++ b/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/context/binder-context.xml
@@ -2,6 +2,7 @@
 <!DOCTYPE beans PUBLIC '-//SPRING//DTD BEAN//EN' 'http://www.springframework.org/dtd/spring-beans.dtd'>
 <beans>
 
+
     <bean id="alfred-telemetry.MeterBinderRegistrar"
             class="eu.xenit.alfred.telemetry.binder.MeterBinderRegistrar">
         <constructor-arg ref="meterRegistry"/>

--- a/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/context/service-context.xml
+++ b/alfred-telemetry-platform/src/main/resources/alfresco/module/alfred-telemetry-platform/context/service-context.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE beans PUBLIC '-//SPRING//DTD BEAN//EN' 'http://www.springframework.org/dtd/spring-beans.dtd'>
 <beans>
+    <bean id="alfred-telemetry.MicrometerOnClasspathDetector"
+          class="eu.xenit.alfred.telemetry.service.MicrometerOnClasspathDetector" />
 
     <bean id="alfred-telemetry.MeterRegistryService"
             class="eu.xenit.alfred.telemetry.service.MeterRegistryService">

--- a/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/registry/RegistryRegistrarTest.java
+++ b/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/registry/RegistryRegistrarTest.java
@@ -7,19 +7,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import eu.xenit.alfred.telemetry.service.VersionUtilTest;
-import eu.xenit.alfred.telemetry.util.VersionUtil.Version;
+import eu.xenit.alfred.telemetry.util.MicrometerModules.Version;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Collections;
-import org.junit.Before;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.support.GenericXmlApplicationContext;
 
 @ExtendWith(MockitoExtension.class)
 class RegistryRegistrarTest {

--- a/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/service/VersionUtilTest.java
+++ b/alfred-telemetry-platform/src/test/java/eu/xenit/alfred/telemetry/service/VersionUtilTest.java
@@ -6,8 +6,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 
-import eu.xenit.alfred.telemetry.util.VersionUtil;
-import eu.xenit.alfred.telemetry.util.VersionUtil.Version;
+import eu.xenit.alfred.telemetry.util.MicrometerModules;
+import eu.xenit.alfred.telemetry.util.MicrometerModules.Version;
 import org.junit.jupiter.api.Test;
 
 public class VersionUtilTest {
@@ -24,7 +24,7 @@ public class VersionUtilTest {
     @Test
     void retrieveVersionOfMicrometerModule_core() {
         assertThat(
-                VersionUtil.getMicrometerModuleVersion("micrometer-core"),
+                MicrometerModules.getMicrometerModuleVersion("micrometer-core"),
                 is(equalTo(getMicrometerVersionFromGradle()))
         );
     }
@@ -32,7 +32,7 @@ public class VersionUtilTest {
     @Test
     void retrieveVersionOfMicrometerModule_jmxRegistry() {
         assertThat(
-                VersionUtil.getMicrometerModuleVersion("micrometer-registry-jmx"),
+                MicrometerModules.getMicrometerModuleVersion("micrometer-registry-jmx"),
                 is(equalTo(getMicrometerVersionFromGradle()))
         );
     }

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ allprojects {
         hamcrestVersion = '1.3'
         awaitilityVersion = '4.1.0'
         restAssuredVersion = '4.0.0'
+        assertjVersion = '3.16.1'
     }
 
     // It is not possible to set properties with a dot via GitHub Actions env variables, therefore we introduce support

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,6 @@ allprojects {
         hamcrestVersion = '1.3'
         awaitilityVersion = '4.1.0'
         restAssuredVersion = '4.0.0'
-        assertjVersion = '3.16.1'
     }
 
     // It is not possible to set properties with a dot via GitHub Actions env variables, therefore we introduce support

--- a/integration-tests/alfresco-community-52/overload.gradle
+++ b/integration-tests/alfresco-community-52/overload.gradle
@@ -2,4 +2,13 @@ ext {
     alfrescoBaseWar = 'org.alfresco:alfresco-platform:5.2.g@war'
     alfrescoBaseImage = 'docker.io/xenit/alfresco-repository-community:5.2.g'
     solrFlavor = 'solr4'
+
+    extraDependencies = [
+            "io.micrometer:micrometer-core:${micrometerVersion}",
+            "io.github.mweirauch:micrometer-jvm-extras:${jvmExtrasVersion}",
+
+            "io.micrometer:micrometer-registry-graphite:${micrometerVersion}",
+            "io.micrometer:micrometer-registry-jmx:${micrometerVersion}",
+            "io.micrometer:micrometer-registry-prometheus:${micrometerVersion}"
+    ]
 }

--- a/integration-tests/alfresco-community-60/overload.gradle
+++ b/integration-tests/alfresco-community-60/overload.gradle
@@ -2,4 +2,13 @@ ext {
     alfrescoBaseWar = 'org.alfresco:content-services-community:6.0.7-ga@war'
     alfrescoBaseImage = 'docker.io/xenit/alfresco-repository-community:6.0.7-ga'
     solrFlavor = 'solr6'
+
+    extraDependencies = [
+            "io.micrometer:micrometer-core:${micrometerVersion}",
+            "io.github.mweirauch:micrometer-jvm-extras:${jvmExtrasVersion}",
+
+            "io.micrometer:micrometer-registry-graphite:${micrometerVersion}",
+            "io.micrometer:micrometer-registry-jmx:${micrometerVersion}",
+            "io.micrometer:micrometer-registry-prometheus:${micrometerVersion}"
+    ]
 }

--- a/integration-tests/alfresco-community-61/overload.gradle
+++ b/integration-tests/alfresco-community-61/overload.gradle
@@ -2,4 +2,13 @@ ext {
     alfrescoBaseWar = 'org.alfresco:content-services-community:6.1.2-ga@war'
     alfrescoBaseImage = 'docker.io/xenit/alfresco-repository-community:6.1.2-ga'
     solrFlavor = 'solr6'
+
+    extraDependencies = [
+            "io.micrometer:micrometer-core:${micrometerVersion}",
+            "io.github.mweirauch:micrometer-jvm-extras:${jvmExtrasVersion}",
+
+            "io.micrometer:micrometer-registry-graphite:${micrometerVersion}",
+            "io.micrometer:micrometer-registry-jmx:${micrometerVersion}",
+            "io.micrometer:micrometer-registry-prometheus:${micrometerVersion}"
+    ]
 }

--- a/integration-tests/alfresco-community-62/overload.gradle
+++ b/integration-tests/alfresco-community-62/overload.gradle
@@ -2,4 +2,13 @@ ext {
     alfrescoBaseWar = 'org.alfresco:content-services-community:6.2.0-ga@war'
     alfrescoBaseImage = 'docker.io/xenit/alfresco-repository-community:6.2.0-ga'
     solrFlavor = 'solr6'
+
+    extraDependencies = [
+            "io.micrometer:micrometer-core:${micrometerVersion}",
+            "io.github.mweirauch:micrometer-jvm-extras:${jvmExtrasVersion}",
+
+            "io.micrometer:micrometer-registry-graphite:${micrometerVersion}",
+            "io.micrometer:micrometer-registry-jmx:${micrometerVersion}",
+            "io.micrometer:micrometer-registry-prometheus:${micrometerVersion}"
+    ]
 }

--- a/integration-tests/alfresco-community-70/overload.gradle
+++ b/integration-tests/alfresco-community-70/overload.gradle
@@ -1,8 +1,15 @@
 ext {
     alfrescoBaseWarBom = 'org.alfresco:acs-community-packaging:7.0.0'
     alfrescoBaseWar = 'org.alfresco:content-services-community@war'
-
     alfrescoBaseImage = 'docker.io/xenit/alfresco-repository-community:7.0.0'
-    
     solrFlavor = 'solr6'
+
+    extraDependencies = [
+            "io.micrometer:micrometer-core:${micrometerVersion}",
+            "io.github.mweirauch:micrometer-jvm-extras:${jvmExtrasVersion}",
+
+            "io.micrometer:micrometer-registry-graphite:${micrometerVersion}",
+            "io.micrometer:micrometer-registry-jmx:${micrometerVersion}",
+            "io.micrometer:micrometer-registry-prometheus:${micrometerVersion}"
+    ]
 }

--- a/integration-tests/alfresco-enterprise-52/overload.gradle
+++ b/integration-tests/alfresco-enterprise-52/overload.gradle
@@ -2,4 +2,13 @@ ext {
     alfrescoBaseWar = 'org.alfresco:alfresco-enterprise:5.2.7.3@war'
     alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:5.2.7.3'
     solrFlavor = 'solr4'
+
+    extraDependencies = [
+            "io.micrometer:micrometer-core:${micrometerVersion}",
+            "io.github.mweirauch:micrometer-jvm-extras:${jvmExtrasVersion}",
+
+            "io.micrometer:micrometer-registry-graphite:${micrometerVersion}",
+            "io.micrometer:micrometer-registry-jmx:${micrometerVersion}",
+            "io.micrometer:micrometer-registry-prometheus:${micrometerVersion}"
+    ]
 }

--- a/integration-tests/alfresco-enterprise-60/overload.gradle
+++ b/integration-tests/alfresco-enterprise-60/overload.gradle
@@ -2,4 +2,13 @@ ext {
     alfrescoBaseWar = 'org.alfresco:content-services:6.0.1.3@war'
     alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.0.1.3'
     solrFlavor = 'solr6'
+
+    extraDependencies = [
+            "io.micrometer:micrometer-core:${micrometerVersion}",
+            "io.github.mweirauch:micrometer-jvm-extras:${jvmExtrasVersion}",
+
+            "io.micrometer:micrometer-registry-graphite:${micrometerVersion}",
+            "io.micrometer:micrometer-registry-jmx:${micrometerVersion}",
+            "io.micrometer:micrometer-registry-prometheus:${micrometerVersion}"
+    ]
 }

--- a/integration-tests/alfresco-enterprise-62/overload.gradle
+++ b/integration-tests/alfresco-enterprise-62/overload.gradle
@@ -1,5 +1,6 @@
 ext {
-    alfrescoBaseWar = 'org.alfresco:content-services:6.2.1@war'
-    alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.2.1'
+    alfrescoBaseWarBom = 'org.alfresco:acs-packaging:6.2.2.19'
+    alfrescoBaseWar = 'org.alfresco:content-services@war'
+    alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.2.2'
     solrFlavor = 'solr6'
 }

--- a/integration-tests/alfresco-enterprise-62/overload.gradle
+++ b/integration-tests/alfresco-enterprise-62/overload.gradle
@@ -1,6 +1,6 @@
 ext {
     alfrescoBaseWarBom = 'org.alfresco:acs-packaging:6.2.2.19'
     alfrescoBaseWar = 'org.alfresco:content-services@war'
-    alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.2.2'
+    alfrescoBaseImage = 'hub.xenit.eu/alfresco-enterprise/alfresco-repository-enterprise:6.2.2.19'
     solrFlavor = 'solr6'
 }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -5,6 +5,7 @@ plugins {
 
 ext {
     slf4jVersion = '1.7.25'
+    extraDependencies = []
 }
 
 java {
@@ -69,14 +70,13 @@ subprojects {
     dependencies {
         alfrescoAmp project(path: ":alfred-telemetry-platform", configuration: "amp")
 
-        // If customers want to use specific MeterRegistries, they should be added to the classpath:
-        alfrescoSM "io.micrometer:micrometer-registry-graphite:${micrometerVersion}"
-        alfrescoSM "io.micrometer:micrometer-registry-jmx:${micrometerVersion}"
-        alfrescoSM "io.micrometer:micrometer-registry-prometheus:${micrometerVersion}"
-
         if (project.hasProperty("alfrescoBaseWarBom")) {
             baseAlfrescoWar platform("${alfrescoBaseWarBom}")
         }
+
+        // load extra dependencies from overload.gradle
+        alfrescoSM project.extraDependencies
+
         baseAlfrescoWar "${alfrescoBaseWar}"
     }
 


### PR DESCRIPTION
On ACE (all versions) or EE < v6.1, you need to add the micrometer dependencies yourself:

```groovy
alfrescoSM "io.micrometer:micrometer-core:${micrometerVersion}"
alfrescoSM "io.github.mweirauch:micrometer-jvm-extras:${jvmExtrasVersion}"
```

Alfresco will crash at startup if `alfred-telemetry` is installed, but the required dependencies are missing, with following errors respectively:

`micrometer-core` missing:
```
java.lang.RuntimeException: Required dependency 'io.micrometer:micrometer-core' is not found on the classpath!
        at eu.xenit.alfred.telemetry.service.MicrometerOnClasspathDetector.postProcessBeanDefinitionRegistry(MicrometerOnClasspathDetector.java:14)
```

`micrometer-jvm-extras` missing:
```
Caused by: java.lang.RuntimeException: Missing dependency 'io.github.mweirauch:micrometer-jvm-extras' or disable binder with 'alfred.telemetry.binder.process.enabled=false'
        at eu.xenit.alfred.telemetry.binder.ProcessMetrics.bindTo(ProcessMetrics.java:20)

```

This fixes #96 